### PR TITLE
Added check for issues to see if they are pull requests

### DIFF
--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -46,8 +46,8 @@ export default {
 			issues = issues.filter(issue => {
 				const now = moment().isoWeekday(1)
 				const issueDate = moment(issue.created_at).isoWeekday(1)
-
-				return now.isSame(issueDate, 'week')
+				const isPullRequest = issue.hasOwnProperty('pull_request')
+				return now.isSame(issueDate, 'week') && !isPullRequest
 			})
 
 			return new Promise((resolve, reject) => {


### PR DESCRIPTION
Github api provides pull requests even though it's the issue endpoint. Pull requests can be identified by the existence of the property "pull_request"